### PR TITLE
Incorporate externally pre-computed weighting of per-SNP heritability

### DIFF
--- a/h2weight.R
+++ b/h2weight.R
@@ -1,0 +1,75 @@
+# R code to generate *.h2weight files
+# The *.h2weight files are used in Popcorn compute mode with --h2weight option.
+
+# Precomputed *.h2weight files are available here
+# (so you don't need to run this R code)
+# http://103.253.147.127/popcorn/h2weight.20170802.zip
+# http://www.fumihiko.takeuchi.name/popcorn/h2weight.20170802.zip
+
+# The purpose of --h2weight option is to incorporate the dependence of
+# per-SNP heritability on allele frequency and LD-related functional annotations.
+# The *.h2weight files specify the prior weight.
+#
+# Allele frequency weighting is alpha = -0.25 according to
+# [Speed et al. (2017) doi:10.1038/ng.3865].
+# LD-related weighting is taken from
+# [Gazal et al. (2017) doi:10.1038/ng.3954 Fig. 3c, Table S8a].
+
+# The following files are required to run this R code:
+# Allele frequency data of 1000G population in PLINK .frq format.
+# LD-related data files baselineLD.*.annot distributed
+#  https://data.broadinstitute.org/alkesgroup/LDSCORE/
+
+for (p in c("EAS", "EUR", "SAS")) { # population
+  print(p);
+  
+  # load input data
+  c = 1 # chromosome
+  data = read.table(
+    paste0("~/human/1000G/phase3_shapeit2/",p,".chr",c,".maf001.snv.frq"),
+    header=T, stringsAsFactors=F)
+  ld = read.table(
+    paste0("~/human/ldsc/1000G_Phase3_baselineLD_ldscores/baselineLD.",c,".annot_c2_73-78"),
+    header=T, stringsAsFactors=F)
+  ldnames = names(ld)[-1]
+  print(table(data$SNP %in% ld$SNP))
+  data[, ldnames] = ld[match(data$SNP, ld$SNP), ldnames]
+  for (c in (2:22)) {
+    foo = read.table(
+      paste0("~/human/1000G/phase3_shapeit2/",p,".chr",c,".maf001.snv.frq"),
+      header=T, stringsAsFactors=F)
+    ld = read.table(
+      paste0("~/human/ldsc/1000G_Phase3_baselineLD_ldscores/baselineLD.",c,".annot_c2_73-78"),
+      header=T, stringsAsFactors=F)
+    print(table(foo$SNP %in% ld$SNP))
+    foo[, ldnames] = ld[match(foo$SNP, ld$SNP), ldnames]
+    data = rbind(data, foo)
+  }
+
+  # compute h2weight
+  taulist = c(-0.24, -0.20, -0.20, -0.13, 0.11, 0.23)
+  for (i in 1:6) {
+    ldname = ldnames[i];
+    tau = taulist[i];
+    x = data[, ldname];
+    data[, ldname] = exp(tau*(x - mean(x, na.rm=T))/sd(x, na.rm=T))
+  }
+  #
+  alpha = -0.25
+  data$MAFweight = (2 * data$MAF * (1 - data$MAF))^(1 + alpha)
+  data$h2weight = apply(data[, c(ldnames,"MAFweight")], 1, prod)
+
+  # output
+  #print(cor(log(data[, c(ldnames,"MAFweight","h2weight")]), use="complete.obs"))
+  for (c in 1:22) {
+    output = data[data$CHR==c, c("SNP", "h2weight")];
+    # check again if SNPs match with plink bed/bim/fam
+    foo = read.table(
+      paste0("~/human/1000G/phase3_shapeit2/",p,".chr",c,".maf001.snv.bim"),
+      header=F, stringsAsFactors=F)
+    if(!all(output$SNP==foo$V2)) { print("ERROR"); break }
+    write.table(output,
+                paste0("~/human/1000G/phase3_shapeit2/",p,".chr",c,".maf001.snv.h2weight"),
+                quote=F, row.names=F, col.names=F, sep="\t")
+  }
+}

--- a/popcorn/__main__.py
+++ b/popcorn/__main__.py
@@ -52,6 +52,10 @@ def main(args=None):
                                ' correlation. This must be specified both'
                                ' when computing scores and fitting the model.',
                                default=False,action='store_true')
+    parent_parser.add_argument('--h2weight',help='Incorporate per-SNP h2'
+                               ' weighting from file. The filename should be'
+                               ' (radix of binary plink file).h2weight',
+                               default=False,action='store_true')
     parent_parser.add_argument('--from_bp',default=None,type=int,help='Specify'
                                ' base position to start analysis.')
     parent_parser.add_argument('--to_bp',default=None,type=int,help='Specify'

--- a/popcorn/compute.py
+++ b/popcorn/compute.py
@@ -160,6 +160,8 @@ class covariance_scores_1_pop(object):
                 v = h2w1/v1m
                 v1j = h2w1[-1]/v1m
                 c = a**2
+                if not args.use_bias:
+                    c = c - (1-c)/(N-2)
                 return (v*c).sum(1), (v1j*(c)).sum(0)[0:-1]
         else:
             def func(a, i, j):
@@ -422,6 +424,9 @@ class covariance_scores_2_pop(covariance_scores_1_pop):
                 v1j = h2w1[-1]/v1m
                 v2j = h2w2[-1]/v2m
                 c = a*b
+                if not args.use_bias:
+                    correction = (1 - np.abs(c))/np.sqrt((self.N[0]-2)*(self.N[1]-2))
+                    c = c - np.sign(c)*correction
                 return (v*c).sum(1), (np.sqrt(v1j*v2j)*(c)).sum(0)[0:-1]
         else:
             def func(a,b,i,j):


### PR DESCRIPTION
The change is related to the description at the very end of your AJHG article:
Maximum-likelihood approaches are well suited to different genetic architectures.
For example, one could estimate both the global relationship between allele frequency 
and effect size ...
We expect that incorporating these parameters will improve estimates of heritability and genetic correlation

As you might know, there have been publications on the dependence of per-SNP heritability on allele frequency and LD-related functional annotations.
http://dx.doi.org/10.1038/ng.3865
http://dx.doi.org/10.1038/ng.3954

I thought it would be simple to externally pre-compute these 'global relationship' and fetch it as files during the Popcorn compute mode.
The auxiliary files (*.h2weight) specify prior weighting of per-SNP heritability for each SNP.
The *.h2weight files were generated using an R script h2weight.R
As for the interface of the Popcorn program, one option --h2weight was added.