### PR TITLE
Fixes #23 KeyError: ['beta', 'SE'] when using Z

### DIFF
--- a/popcorn/sumstats.py
+++ b/popcorn/sumstats.py
@@ -45,6 +45,7 @@ class sumstats_1_trait(object):
                         "compliment SNPs.")
 
     def parse_input(self, sfile):
+        print('Parse', sfile, '...')
         DF = pd.read_table(sfile)
         data = pd.DataFrame()
         try:
@@ -58,6 +59,7 @@ class sumstats_1_trait(object):
                 try:
                     data['id'] = 'chr'+DF['chr'].map(str)+':'+DF['pos'].map(str)
                     id_type = 'pos'
+                    print('Note: CHR:POS will be used as SNP identifier')
                 except KeyError:
                     raise ValueError('Must provide either "rsid", "SNP"'
                                              ' or "chr" and "pos"')
@@ -85,6 +87,8 @@ class sumstats_1_trait(object):
         try:
             data['beta'] = DF['beta']
             data['SE'] = DF['SE']
+            if 'Z' in data.columns:
+                print('Note: Z column will be re-calculated from beta and SE')
             data['Z'] = data['beta']/data['SE']
         except KeyError:
             try:
@@ -96,6 +100,7 @@ class sumstats_1_trait(object):
                     data['beta'] = beta
                     data['SE'] = SE
                     data['Z'] = Z
+                    print('Note: beta, SE and Z will be calculated from OR and p-value columns')
                 except KeyError:
                     raise ValueError(
                         'Must provide either signed Z-scores 1) "Z", 2) "beta" and "SE",'
@@ -105,7 +110,7 @@ class sumstats_1_trait(object):
         valid_alleles = np.logical_and(has_comp['a1'], has_comp['a2'])
         data=data.loc[valid_alleles]
         data.replace([np.inf, -np.inf], np.nan, inplace=True)
-        data.dropna(subset=['id', 'a1', 'a2', 'N', 'beta', 'SE', 'Z'], inplace=True)
+        data.dropna(subset={'id', 'a1', 'a2', 'N', 'beta', 'SE', 'Z'}.intersection(data.columns), inplace=True)
         # else:
         #     data = pd.read_table(sfile,sep='\t',header=None,
         #                          names=['chr','id','pos','af','a1','a2',


### PR DESCRIPTION
This change fixes #23 KeyError: ['beta', 'SE'] when using Z.

It also adds a few print statements to inform the user when popcorn uses CHR:POS  as SNP identifier, or when popcorn re-calculates Z column from beta and SE. Both steps are convenient to have, but in some cases they might be problematic, and thus it's good to bring them to user's attention. The problem with CHR:POS as identifier is that two different variants could have the same location, so CHR:POS is somewhat ambiguous as an identifier. The problem with re-calculating Z is that this behaviour is somewhat not intuitive - I would expect that if Z score is provided in the input popcorn will take it as use as it is, even if ``beta`` and ``SE`` columns are also specified. I would suggest to add a line in the readme to clarify that  if ``beta`` and ``SE`` are provided, then popcorn will use those and ignore ``Z`` column if it's part of the input summary statistics.  